### PR TITLE
feat: limit how news pages can be organized

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example urls
 - [x] Get local `docker-compose` based development setup functional and documented
 - [x] Get local editor tooling functional and documented
 - [ ] Get staging environment up and running using terraform (in another repo for now)
-- [ ] Limit sub-page types available on `aktuelt` app
+- [x] Limit sub-page types available on `aktuelt` app
 - [ ] Start iterating on `aktuelt` app to get a minimal realistic and functional article setup in place  (look at existing page for inspiration)
 - [ ] Iterate on README and other docs to include any relevant commands and setup steps
 

--- a/aktuelt/models.py
+++ b/aktuelt/models.py
@@ -32,6 +32,8 @@ class NewsTagIndexPage(Page):
 
 
 class NewsIndexPage(Page):
+    subpage_types = ["aktuelt.NewsPage"]
+
     intro = RichTextField(blank=True)
 
     content_panels = Page.content_panels + [FieldPanel("intro")]
@@ -44,6 +46,9 @@ class NewsIndexPage(Page):
 
 
 class NewsPage(Page):
+    parent_page_types = ["aktuelt.NewsIndexPage"]
+    subpage_types = []
+
     date = models.DateField("Post date")
     intro = models.CharField(max_length=250)
     body = RichTextField(blank=True)

--- a/aktuelt/tests.py
+++ b/aktuelt/tests.py
@@ -65,7 +65,7 @@ class AktueltSanityChecks(WagtailPageTestCase):
         response = self.client.get(newsPage.get_url() or "/invalid-url/")
         self.assertEqual(response.status_code, 404)
 
-        
+
 class AktueltNewsPageStructure(WagtailPageTestCase):
     def test_news_page_can_only_be_created_under_news_index_page(self):
         self.assertAllowedParentPageTypes(NewsPage, {NewsIndexPage})

--- a/aktuelt/tests.py
+++ b/aktuelt/tests.py
@@ -1,3 +1,11 @@
-# from django.test import TestCase
+from wagtail.test.utils import WagtailPageTestCase
 
-# Create your tests here.
+from .models import NewsIndexPage, NewsPage
+
+
+class AktueltNewsPageStructure(WagtailPageTestCase):
+    def test_news_page_can_only_be_created_under_news_index_page(self):
+        self.assertAllowedParentPageTypes(NewsPage, {NewsIndexPage})
+
+    def test_news_page_index_can_only_hace_news_pages_as_children(self):
+        self.assertAllowedSubpageTypes(NewsIndexPage, {NewsPage})


### PR DESCRIPTION
Minor improvements on news pages, only allowing them to be organised in the expected manner. A good example of Wagtail concepts we need to be aware of and can potentially use to our advantage over time, by default it allows any type of page to be nested under any other type of page.

This config limits news page hierarchy in `aktuelt` to
`NewsIndexPage > NewsPage[]`

Pending https://github.com/gathering/tgno-backend/pull/4