### PR TITLE
feat: improved seeding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ migrate:
 createsuperuser:
 	docker compose exec web python manage.py createsuperuser
 
+mode = refresh
 seed-for-development:
-	docker compose exec web python manage.py seed
+	docker compose exec web python manage.py seed --mode=$(mode)
 
 # Run to trigger publishing of scheduled content when developing locally
 # in production we run a cronjob that runs the wagtail command every x minutes

--- a/commands/management/commands/seed.py
+++ b/commands/management/commands/seed.py
@@ -4,13 +4,7 @@ from treebeard.exceptions import NodeAlreadySaved
 from wagtail.models import Page, Site
 
 from aktuelt.constants import ContributionTypes
-from aktuelt.models import (
-    Contributor,
-    NewsIndexPage,
-    NewsPage,
-    NewsPageContributor,
-    NewsPageTag,
-)
+from aktuelt.models import Contributor, NewsIndexPage, NewsPage, NewsPageContributor
 from home.models import HomePage
 
 # python manage.py seed --mode=refresh
@@ -44,6 +38,7 @@ def NEWS_SEED_DATA():
             # First entry is the news item
             dict(
                 title="First news",
+                slug="seed-first-news",
                 intro="Test intro",
                 body="Test body",
             ),
@@ -59,6 +54,7 @@ def NEWS_SEED_DATA():
         [
             dict(
                 title="Second news",
+                slug="seed-second-news",
                 intro="Test intro",
                 body="Test body",
             ),
@@ -70,6 +66,7 @@ def NEWS_SEED_DATA():
         [
             dict(
                 title="Third news",
+                slug="seed-third-news",
                 intro="Test intro",
                 body="Test body",
             ),
@@ -86,6 +83,7 @@ def NEWS_SEED_DATA():
         [
             dict(
                 title="Forth news",
+                slug="seed-forth-news",
                 intro="Test intro",
                 body="Test body",
             ),
@@ -99,6 +97,7 @@ def NEWS_SEED_DATA():
         [
             dict(
                 title="Fifth news",
+                slug="seed-fifth-news",
                 intro="Test intro",
                 body="Test body",
             ),
@@ -179,9 +178,9 @@ class Command(BaseCommand):
         for raw_news in NEWS_SEED_DATA():
             news, meta = raw_news
             try:
-                newsPage = NewsPage.objects.get(title=news["title"])
+                newsPage = NewsPage.objects.get(slug=news["slug"])
             except NewsPage.MultipleObjectsReturned:
-                newsPage = NewsPage.objects.filter(title=news["title"]).first()
+                newsPage = NewsPage.objects.filter(slug=news["slug"]).first()
             except NewsPage.DoesNotExist:
                 newsPage = NewsPage()
 

--- a/commands/management/commands/seed.py
+++ b/commands/management/commands/seed.py
@@ -1,8 +1,16 @@
 from django.core.management.base import BaseCommand
+from taggit.models import Tag
 from treebeard.exceptions import NodeAlreadySaved
 from wagtail.models import Page, Site
 
-from aktuelt.models import NewsIndexPage, NewsPage
+from aktuelt.constants import ContributionTypes
+from aktuelt.models import (
+    Contributor,
+    NewsIndexPage,
+    NewsPage,
+    NewsPageContributor,
+    NewsPageTag,
+)
 from home.models import HomePage
 
 # python manage.py seed --mode=refresh
@@ -12,6 +20,94 @@ MODE_REFRESH = "refresh"
 
 """ Insert, update, and clear all existin entries from the related tables """
 MODE_CLEAR = "clear"
+
+""" Data to be inserted """
+
+TAGS_DATA = [
+    dict(name="News"),
+    dict(name="Events"),
+    dict(name="Announcements"),
+    dict(name="Updates"),
+]
+
+CONTRIBUTORS_DATA = [
+    dict(name="John Doe", default_contribution_type=ContributionTypes.TEXT),
+    dict(name="Jane Doe", default_contribution_type=ContributionTypes.VIDEO),
+    dict(name="Alice", default_contribution_type=ContributionTypes.AUDIO),
+    dict(name="Bob", default_contribution_type=ContributionTypes.PHOTOGRAPHY),
+]
+
+
+def NEWS_SEED_DATA():
+    return [
+        [
+            # First entry is the news item
+            dict(
+                title="First news",
+                intro="Test intro",
+                body="Test body",
+            ),
+            # Second are attributes that need to be handled separately
+            dict(
+                tags=["News", "Events"],
+                contributors=[
+                    NewsPageContributor(contributor=Contributor.objects.get(name="John Doe")),
+                    NewsPageContributor(contributor=Contributor.objects.get(name="Jane Doe")),
+                ],
+            ),
+        ],
+        [
+            dict(
+                title="Second news",
+                intro="Test intro",
+                body="Test body",
+            ),
+            dict(
+                tags=["Announcements", "Updates"],
+                contributors=[],
+            ),
+        ],
+        [
+            dict(
+                title="Third news",
+                intro="Test intro",
+                body="Test body",
+            ),
+            dict(
+                tags=["News"],
+                contributors=[
+                    NewsPageContributor(contributor=Contributor.objects.get(name="John Doe")),
+                    NewsPageContributor(
+                        contributor=Contributor.objects.get(name="Alice"), contribution_type="Audio and video"
+                    ),
+                ],
+            ),
+        ],
+        [
+            dict(
+                title="Forth news",
+                intro="Test intro",
+                body="Test body",
+            ),
+            dict(
+                tags=["Announcements", "News"],
+                contributors=[
+                    NewsPageContributor(contributor=Contributor.objects.get(name="Bob")),
+                ],
+            ),
+        ],
+        [
+            dict(
+                title="Fifth news",
+                intro="Test intro",
+                body="Test body",
+            ),
+            dict(
+                tags=[],
+                contributors=[],
+            ),
+        ],
+    ]
 
 
 class Command(BaseCommand):
@@ -28,7 +124,8 @@ class Command(BaseCommand):
         try:
             parent.add_child(instance=child)
         except NodeAlreadySaved:
-            self.stdout.write(f"{child} likely already exists on {parent}. Skipping")
+            self.stdout.write(f"{child} likely already exists on {parent}. Only saving changes to page itself.")
+            child.save()
 
     def SeedSite(self):
         rootPage = Page.objects.get(slug="root")
@@ -56,6 +153,20 @@ class Command(BaseCommand):
         site.root_page = homePage
         site.save()
 
+    def SeedTags(self):
+        for tag in TAGS_DATA:
+            Tag.objects.update_or_create(
+                name=tag["name"],
+                defaults=tag,
+            )
+
+    def SeedContributors(self):
+        for contributor in CONTRIBUTORS_DATA:
+            Contributor.objects.update_or_create(
+                name=contributor["name"],
+                defaults=contributor,
+            )
+
     def SeedAktuelt(self):
         homePage = HomePage.objects.get(title="Seeded content home")
 
@@ -65,50 +176,39 @@ class Command(BaseCommand):
             newsIndexPage = NewsIndexPage(title="Seeded news index")
         self.add_child(homePage, newsIndexPage)
 
-        NEWS_SEED_DATA = [
-            dict(
-                title="First news",
-                intro="Test intro",
-                body="Test body",
-            ),
-            dict(
-                title="Second news",
-                intro="Test intro",
-                body="Test body",
-            ),
-            dict(
-                title="Third news",
-                intro="Test intro",
-                body="Test body",
-            ),
-            dict(
-                title="Forth news",
-                intro="Test intro",
-                body="Test body",
-            ),
-        ]
-
-        for news in NEWS_SEED_DATA:
+        for raw_news in NEWS_SEED_DATA():
+            news, meta = raw_news
             try:
                 newsPage = NewsPage.objects.get(title=news["title"])
             except NewsPage.MultipleObjectsReturned:
                 newsPage = NewsPage.objects.filter(title=news["title"]).first()
             except NewsPage.DoesNotExist:
-                newsPage = NewsPage(**news)
+                newsPage = NewsPage()
+
+            for key in news:
+                setattr(newsPage, key, news[key])
+
+            newsPage.tags.set(meta["tags"])
+            newsPage.news_page_contributors.set(meta["contributors"])
+
             self.add_child(newsIndexPage, newsPage)
 
     def run_clean(self, mode):
-        self.stdout.write("Cleaning data")
         if mode == MODE_CLEAR:
+            self.stdout.write("Clearing data")
             Site.objects.all().delete()  # Sounds a bit too dangerous?
             HomePage.objects.all().delete()
+            Tag.objects.all().delete()
+            Contributor.objects.all().delete()
             NewsIndexPage.objects.all().delete()
             NewsPage.objects.all().delete()
         else:
-            self.stdout.write("Running in refresh mode. No data cleaned.")
+            self.stdout.write("Running in refresh mode. No data cleared.")
 
     def run_seed(self, mode):
         self.stdout.write("Seeding site and home data")
         self.SeedSite()
         self.stdout.write("Seeding aktuelt data")
+        self.SeedTags()
+        self.SeedContributors()
         self.SeedAktuelt()


### PR DESCRIPTION
Follows up on initial seeding support to get it "production" ready (still only safe to use in dev environments where data is worthless).

It
- Adds tags and contributors to seed articles (and by extension shows a pattern for this that can be reused)
- Makes article updating a bit more predictable by using slug as index instead of title