### PR TITLE
feat: resolve links and embeds in news body

### DIFF
--- a/aktuelt/models.py
+++ b/aktuelt/models.py
@@ -12,6 +12,7 @@ from wagtail.snippets.models import register_snippet
 from aktuelt.constants import ContributionTypes
 from aktuelt.serializers import (
     ContributorsSerializer,
+    NewsBodySerializer,
     NewsImageSerializer,
     NewsPageGallerySerializer,
     NewsPageTagsSerializer,
@@ -99,7 +100,7 @@ class NewsPage(Page):
 
     api_fields = [
         APIField("intro"),
-        APIField("body"),
+        APIField("body", serializer=NewsBodySerializer()),
         # TODO: Replace with prettier (main model based?) serializer pattern?
         APIField("contributors", serializer=ContributorsSerializer(source="news_page_contributors")),
         APIField("tags", serializer=NewsPageTagsSerializer()),

--- a/aktuelt/serializers.py
+++ b/aktuelt/serializers.py
@@ -1,5 +1,11 @@
 from rest_framework.fields import Field
 from wagtail.images.api.fields import ImageRenditionField
+from wagtail.rich_text import expand_db_html
+
+
+class NewsBodySerializer(Field):
+    def to_representation(self, value):
+        return expand_db_html(value)
 
 
 class NewsImageSerializer(Field):


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-backend/issues/19

Tried to get a more complete solution in place, but hit a lot of undocumented(?) or unsupported(?) wagtail parts. Will make a separate draft PR with some of the leftovers too show theory.

What we get in this PR
- Links in body is resolved to html Wagtail would use in own frontend
- Embeds (including image embeds) in body is resolved to html Wagtail would use in own frontend

What a future and better version would deliver
- More sophisticated markup with absolute urls, srcset, etc
- More granular adjustments on links and other embed types
- Limited, but frontend supported, image positions/variants
- ... or alternatively we could deliver data as json array and convert to html on frontend side (I think this is my current favourite since it decouples backend and frontend code more)