### PR TITLE
feat: adjust localization

### DIFF
--- a/tgno/settings/base.py
+++ b/tgno/settings/base.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     "wagtail.api.v2",
     "rest_framework",  # Provides a browser friendly UI for exploring the API
     "wagtail",
+    "wagtail.locales",
     "modelcluster",
     "taggit",
     "health_check",

--- a/tgno/settings/base.py
+++ b/tgno/settings/base.py
@@ -140,7 +140,24 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+# Default language code used on content
+LANGUAGE_CODE = "no"
+
+# Frontend languages (not relevant for us, but needs to be filled in since it limits most of the other options)
+LANGUAGES = [
+    ("en", "English"),
+    ("no", "Norwegian"),
+]
+
+# Languages permitted for admin GUI (Norwegian translation is flaky, so disabled)
+WAGTAILADMIN_PERMITTED_LANGUAGES = [("en", "English")]
+
+# Languages permitted for produced content
+# TODO: Uncomment english when frontend experience is nice and ready
+WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
+    ("no", "Norwegian"),
+    #    ('en', "English"),
+]
 
 TIME_ZONE = "UTC"
 


### PR DESCRIPTION
Backend part of: https://github.com/gathering/tgno-frontend/pull/57

Default site locale during setup was english so we both need to change default to Norwegian and change locale on existing content. We use `wagtail.locales` both to avoid having to write migrations for each locale config change, and since it seems to handle default locale change gracefully.

Once release we need to (before frontend can be released)
1. Login as admin and go to new locales section
2. There should be a warning on "English" locale since we disable it (both to avoid current use, but also since it helps migration)
3. On "English" locale resolve warning by selecting "migrate to Norwegian" equivalent option
4. Validate that existing articles now have `no` locale via `https://www.tg.no/api/v2/news/?fields=locale`