### PR TITLE
fix: temp fix to allow non-admins to login

### DIFF
--- a/tgno/settings/base.py
+++ b/tgno/settings/base.py
@@ -228,7 +228,9 @@ LOGIN_REDIRECT_URL = "/admin"
 if SOCIAL_AUTH_KEYCLOAK_KEY is not None:
     AUTHENTICATION_BACKENDS.append("social_core.backends.keycloak.KeycloakOAuth2")
 
-if DISABLE_LOCAL_AUTH is False:
-    AUTHENTICATION_BACKENDS.append("django.contrib.auth.backends.ModelBackend")
+# if DISABLE_LOCAL_AUTH is False:
+#    AUTHENTICATION_BACKENDS.append("django.contrib.auth.backends.ModelBackend")
+# Add ModelBackend anyways to fix groups
+AUTHENTICATION_BACKENDS.append("django.contrib.auth.backends.ModelBackend")
 
 HEALTH_CHECK = {"SUBSETS": {"liveness": ["DatabaseBackend"]}}


### PR DESCRIPTION
Looks like `django.contrib.auth.backends.ModelBackend` is needed for non-admins to login. Note that this will allow users to set a password on the user and login directly to django-admin.