### PR TITLE
feat: require debug mode for browsable api

### DIFF
--- a/aktuelt/api.py
+++ b/aktuelt/api.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.views import PagesAPIViewSet
 
@@ -11,5 +13,21 @@ class NewsPagesAPIViewSet(PagesAPIViewSet):
 
     meta_fields = PagesAPIViewSet.meta_fields + ["last_published_at"]
 
+    # To disable rest_framework's default browsable renderer
+    # - https://github.com/wagtail/wagtail/issues/6066
+    #   (outlines how they secretly ignore/override default REST_FRAMEWORK config options)
+    # - https://docs.wagtail.org/en/stable/advanced_topics/api/v2/configuration.html#enable-the-app
+    #   (says rest_framework is optional, it isn't)
+    renderer_classes = [
+        JSONRenderer,
+    ]
 
+
+if settings.DEBUG:
+    NewsPagesAPIViewSet.renderer_classes = [
+        JSONRenderer,
+        BrowsableAPIRenderer,
+    ]
+
+print(NewsPagesAPIViewSet.renderer_classes)
 api_router.register_endpoint("news", NewsPagesAPIViewSet)

--- a/praktisk/api.py
+++ b/praktisk/api.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.views import PagesAPIViewSet
 
@@ -14,9 +16,25 @@ class InfoPagesAPIViewSet(PagesAPIViewSet):
 
     meta_fields = PagesAPIViewSet.meta_fields + ["last_published_at"]
 
+    # To disable rest_framework's default browsable renderer
+    # - https://github.com/wagtail/wagtail/issues/6066
+    #   (outlines how they secretly ignore/override default REST_FRAMEWORK config options)
+    # - https://docs.wagtail.org/en/stable/advanced_topics/api/v2/configuration.html#enable-the-app
+    #   (says rest_framework is optional, it isn't)
+    renderer_classes = [
+        JSONRenderer,
+    ]
+
     def get_queryset(self):
         allowed_models = [InfoIndexPage, InfoPage]
         return super().get_queryset().type(tuple(allowed_models))
+
+
+if settings.DEBUG:
+    InfoPagesAPIViewSet.renderer_classes = [
+        JSONRenderer,
+        BrowsableAPIRenderer,
+    ]
 
 
 api_router.register_endpoint("info", InfoPagesAPIViewSet)

--- a/praktisk/models.py
+++ b/praktisk/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from rest_framework.serializers import ModelSerializer
 from wagtail.api.v2.serializers import (
     BaseSerializer,
     ChildRelationField,

--- a/tgno/api.py
+++ b/tgno/api.py
@@ -1,8 +1,28 @@
+from django.conf import settings
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.images.api.v2.views import ImagesAPIViewSet
 
 # "Base" routes
 # Content/app specific routes existing in each individual app, not here
 
+
+class AppImagesAPIViewSet(ImagesAPIViewSet):
+    # To disable rest_framework's default browsable renderer
+    # - https://github.com/wagtail/wagtail/issues/6066
+    #   (outlines how they secretly ignore/override default REST_FRAMEWORK config options)
+    # - https://docs.wagtail.org/en/stable/advanced_topics/api/v2/configuration.html#enable-the-app
+    #   (says rest_framework is optional, it isn't)
+    renderer_classes = [
+        JSONRenderer,
+    ]
+
+
+if settings.DEBUG:
+    AppImagesAPIViewSet.renderer_classes = [
+        JSONRenderer,
+        BrowsableAPIRenderer,
+    ]
+
 api_router = WagtailAPIRouter("wagtailapi")
-api_router.register_endpoint("images", ImagesAPIViewSet)
+api_router.register_endpoint("images", AppImagesAPIViewSet)


### PR DESCRIPTION
A bit more work than anticipated, but got it working. Seems like `rest_framework` and browsable API are kind of integral to Wagtail default setup. This fix disables it for the current routes/viewsets and future ones need to be handled independently (or we make our default "base" viewsets that we import instead of wagtail ones)

Side note, this manipulation doesn't handle env changes super gracefully, so restart server if changing debug mode.

Closes: https://github.com/gathering/tgno-backend/issues/29