### PR TITLE
fix: set explicit timezone

### DIFF
--- a/tgno/settings/base.py
+++ b/tgno/settings/base.py
@@ -162,7 +162,9 @@ WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
     #    ('en', "English"),
 ]
 
-TIME_ZONE = "UTC"
+WAGTAIL_USER_TIME_ZONES = ["Europe/Oslo"]
+
+TIME_ZONE = "Europe/Oslo"
 
 USE_I18N = True
 


### PR DESCRIPTION
Showed up while playing around with calendar frontend. Today all values in Wagtail admin UI are Zulu/UTC times, meaning if users selects a specific "Norwegian" time and date they will be one or two hours off.

For existing content this isn't a big deal (we mostly don't show/use time) and date is usually quite discrete or unimportant, but for calendar event this becomes quite critical.

Not 100% sure about possible side effects, but this feels like the correct configuration
1. Admin users are locked to Norwegian timezone, and should see that for all relevant fields
2. Values are stored either as Z/UTC in which case it will be offset from what user is shown, or explicitly in local timezone
3. Values delivered via API seem to consistently include timezone information (ex. `Z` or `+01:00` type values at end of datetime values) 