### PR TITLE
feat: include show_in_menus for page children

### DIFF
--- a/praktisk/serializers.py
+++ b/praktisk/serializers.py
@@ -25,6 +25,7 @@ class InfoChildPageSerializer(PageSerializer):
                 "title": entry.title,
                 "url": entry.url,
                 "intro": entry.body,
+                "show_in_menus": entry.show_in_menus,
             }
             for entry in pages.all()
         ]


### PR DESCRIPTION
Allows us to selectively decide which sub-pages to show in navigation