### PR TITLE
feat: require all queried event tags to be present

### DIFF
--- a/program/views.py
+++ b/program/views.py
@@ -60,7 +60,8 @@ class EventsView(generics.ListAPIView):
         )
 
         if tags:
-            queryset = queryset.filter(tags__slug__in=tags.split(","))
+            for tag in tags.split(","):
+                queryset = queryset.filter(tags__slug=tag)
 
         events = api_occurrences(queryset, start, end, timezone)
 


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/191

Makes sure new filtering behaviour in frontend behaves as expected. Now adding a tag to event search will reduce the number of matches (each event needs to match all tags requested) rather than expand it.